### PR TITLE
Removed URC echo matching

### DIFF
--- a/src/urc.rs
+++ b/src/urc.rs
@@ -34,8 +34,6 @@ pub enum URCMessages<const RX_SIZE: usize> {
     DataAvailable(usize, usize),
     /// Received the following data requested by CIPRECVDATA command.
     Data(Vec<u8, RX_SIZE>),
-    /// Echo of a command
-    Echo,
     /// Unknown URC message
     Unknown,
 }
@@ -44,11 +42,6 @@ impl<const RX_SIZE: usize> AtatUrc for URCMessages<RX_SIZE> {
     type Response = Self;
 
     fn parse(resp: &[u8]) -> Option<Self::Response> {
-        // Command echo
-        if &resp[..3] == b"AT+" {
-            return Some(Self::Echo);
-        }
-
         if &resp[..4] == b"+IPD" {
             return URCMessages::parse_data_available(resp);
         }
@@ -220,7 +213,6 @@ impl<'a> LineBasedMatcher<'a> {
     /// True if a regular CRLF terminated URC message was matched
     fn matches_lines_based_urc(&self, line: &str) -> bool {
         line == "ready"
-            || &line[..3] == "AT+"
             || &line[..4] == "+IPD"
             || line == "SEND OK"
             || line == "SEND FAIL"

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -154,7 +154,6 @@ impl<const RX_SIZE: usize> Session<RX_SIZE> {
                 }
             }
             URCMessages::Data(data) => self.data = Some(data),
-            URCMessages::Echo => {}
             URCMessages::Unknown => {}
         }
     }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -259,7 +259,7 @@ impl<A: AtatClient, T: Timer<TIMER_HZ>, const TIMER_HZ: u32, const TX_SIZE: usiz
 
     /// Returns local address information
     fn get_address(&mut self) -> Result<LocalAddress, AddressErrors> {
-        let responses = self.send_command(ObtainLocalAddressCommand::new())?;
+        let responses = self.send_command::<_, 10>(ObtainLocalAddressCommand::new())?;
         LocalAddress::from_responses(responses)
     }
 


### PR DESCRIPTION
As discussed in #13 consuming of echo messages in URC is causing issues.
For example, the first IPv4 address of [get_address()](https://docs.rs/esp-at-nal/0.2.0/esp_at_nal/wifi/trait.WifiAdapter.html#tymethod.get_address) is lost.

In this PR, the derive implementation of `ObtainLocalAddressCommand` was also replaced, since it generated invalid binaries for thumbv6m for reasons still unknown. The problem seems to be related to heapless String.